### PR TITLE
Click 7.0 adjustments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ setup_requires = setuptools_scm
 install_requires =
     appdirs
     attrs
-    click~=6.0
+    click
     filesystems
     packaging
     pytoml>=0.1.16

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -54,6 +54,7 @@ from venvs.common import _FILESYSTEM, _LINK_DIR, _ROOT
 )
 @click.option(
     "-t", "--temp", "--temporary",
+    "temporary",
     flag_value=True,
     help="create or reuse the global temporary virtualenv",
 )

--- a/venvs/tests/test_find.py
+++ b/venvs/tests/test_find.py
@@ -100,7 +100,8 @@ class TestFind(CLIMixin, TestCase):
         stdin, stdout, stderr = self.run_cli(
             ["--random-garbage"], exit_status=2,
         )
+        stderr_ends_with = "Error: no such option: --random-garbage\n"
         self.assertEqual(
-            (stdin, stdout, stderr),
-            ("", stdout, "Error: no such option: --random-garbage\n"),
+            (stdin, stdout, stderr[-len(stderr_ends_with):]),
+            ("", stdout, stderr_ends_with),
         )


### PR DESCRIPTION
The need to add the `"temporary"` to force the name from the "temp" it seemed to be filling in in the tests seems wrong but...  maybe we just live with it.  Or maybe you want it fixed.