### PR TITLE
Edit config file automatically when installing from CLI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     pytoml>=0.1.16
     tqdm
     virtualenv
+    tomlkit
 
 [options.entry_points]
 console_scripts =

--- a/venvs/common.py
+++ b/venvs/common.py
@@ -8,7 +8,23 @@ import sysconfig
 import attr
 import click
 import filesystems.native
+import pytoml
+import tomlkit
 import virtualenv as virtualenv_for_path
+
+
+def load_config(filesystem, locator):
+    with filesystem.open(locator.root.descendant("virtualenvs.toml")) as venvs:
+        text = venvs.read()
+        try:
+            return tomlkit.loads(text)
+        except ValueError:
+            return pytoml.loads(text)
+
+
+def dump_config(config, filesystem, locator):
+    with filesystem.open(locator.root.descendant("virtualenvs.toml"), "w") as venvs:
+        return venvs.write(tomlkit.dumps(config))
 
 
 def _create_virtualenv(virtualenv, arguments, python, stdout, stderr):

--- a/venvs/common.py
+++ b/venvs/common.py
@@ -14,7 +14,7 @@ import virtualenv as virtualenv_for_path
 
 
 def load_config(filesystem, locator):
-    with filesystem.open(locator.root.descendant("virtualenvs.toml")) as venvs:
+    with filesystem.open(locator.root.descendant("virtualenvs.toml"), "rt") as venvs:
         text = venvs.read()
         try:
             return tomlkit.loads(text)
@@ -23,7 +23,7 @@ def load_config(filesystem, locator):
 
 
 def dump_config(config, filesystem, locator):
-    with filesystem.open(locator.root.descendant("virtualenvs.toml"), "w") as venvs:
+    with filesystem.open(locator.root.descendant("virtualenvs.toml"), "wt") as venvs:
         return venvs.write(tomlkit.dumps(config))
 
 

--- a/venvs/common.py
+++ b/venvs/common.py
@@ -22,6 +22,12 @@ def _load_config(filesystem, locator):
 
 
 def _dump_config(config, filesystem, locator):
+
+    try:
+        filesystem.create_directory(locator.root)
+    except filesystems.exceptions.FileExists:
+        pass
+
     with filesystem.open(
             locator.root.descendant("virtualenvs.toml"),
             "wt",

--- a/venvs/common.py
+++ b/venvs/common.py
@@ -13,7 +13,7 @@ import tomlkit
 import virtualenv as virtualenv_for_path
 
 
-def load_config(filesystem, locator):
+def _load_config(filesystem, locator):
     with filesystem.open(locator.root.descendant("virtualenvs.toml"), "rt") as venvs:
         text = venvs.read()
         try:
@@ -22,7 +22,7 @@ def load_config(filesystem, locator):
             return pytoml.loads(text)
 
 
-def dump_config(config, filesystem, locator):
+def _dump_config(config, filesystem, locator):
     with filesystem.open(locator.root.descendant("virtualenvs.toml"), "wt") as venvs:
         return venvs.write(tomlkit.dumps(config))
 

--- a/venvs/common.py
+++ b/venvs/common.py
@@ -8,7 +8,6 @@ import sysconfig
 import attr
 import click
 import filesystems.native
-import pytoml
 import tomlkit
 import virtualenv as virtualenv_for_path
 
@@ -16,10 +15,7 @@ import virtualenv as virtualenv_for_path
 def _load_config(filesystem, locator):
     with filesystem.open(locator.root.descendant("virtualenvs.toml"), "rt") as venvs:
         text = venvs.read()
-        try:
-            return tomlkit.loads(text)
-        except ValueError:
-            return pytoml.loads(text)
+        return tomlkit.loads(text)
 
 
 def _dump_config(config, filesystem, locator):

--- a/venvs/common.py
+++ b/venvs/common.py
@@ -13,13 +13,19 @@ import virtualenv as virtualenv_for_path
 
 
 def _load_config(filesystem, locator):
-    with filesystem.open(locator.root.descendant("virtualenvs.toml"), "rt") as venvs:
+    with filesystem.open(
+            locator.root.descendant("virtualenvs.toml"),
+            "rt",
+    ) as venvs:
         text = venvs.read()
         return tomlkit.loads(text)
 
 
 def _dump_config(config, filesystem, locator):
-    with filesystem.open(locator.root.descendant("virtualenvs.toml"), "wt") as venvs:
+    with filesystem.open(
+            locator.root.descendant("virtualenvs.toml"),
+            "wt",
+    ) as venvs:
         return venvs.write(tomlkit.dumps(config))
 
 

--- a/venvs/converge.py
+++ b/venvs/converge.py
@@ -13,7 +13,7 @@ import click
 import pytoml
 
 from venvs import __version__
-from venvs.common import _FILESYSTEM, _LINK_DIR, _ROOT, load_config
+from venvs.common import _FILESYSTEM, _LINK_DIR, _ROOT, _load_config
 
 
 def _fail(virtualenv):
@@ -41,7 +41,7 @@ def _do_not_fail(virtualenv):
 )
 @click.version_option(version=__version__)
 def main(filesystem, locator, link_dir, handle_error):
-    contents = load_config(filesystem=filesystem, locator=locator)
+    contents = _load_config(filesystem=filesystem, locator=locator)
     progress = tqdm(contents["virtualenv"].items())
     for name, config in progress:
         progress.set_description(name)

--- a/venvs/converge.py
+++ b/venvs/converge.py
@@ -13,7 +13,7 @@ import click
 import pytoml
 
 from venvs import __version__
-from venvs.common import _FILESYSTEM, _LINK_DIR, _ROOT
+from venvs.common import _FILESYSTEM, _LINK_DIR, _ROOT, load_config
 
 
 def _fail(virtualenv):
@@ -41,12 +41,7 @@ def _do_not_fail(virtualenv):
 )
 @click.version_option(version=__version__)
 def main(filesystem, locator, link_dir, handle_error):
-    with filesystem.open(locator.root.descendant("virtualenvs.toml")) as venvs:
-        contents = pytoml.load(
-            venvs,
-            object_pairs_hook=collections.OrderedDict,
-        )
-
+    contents = load_config(filesystem=filesystem, locator=locator)
     progress = tqdm(contents["virtualenv"].items())
     for name, config in progress:
         progress.set_description(name)

--- a/venvs/converge.py
+++ b/venvs/converge.py
@@ -2,7 +2,6 @@
 Converge the set of installed virtualenvs.
 
 """
-import collections
 import os
 import subprocess
 import sys

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -17,7 +17,9 @@ import click
 import tomlkit
 
 from venvs import __version__
-from venvs.common import _FILESYSTEM, _LINK_DIR, _ROOT, _dump_config, _load_config
+from venvs.common import (
+    _FILESYSTEM, _LINK_DIR, _ROOT, _dump_config, _load_config
+)
 
 
 def add_virtualenv_config(filesystem, locator, installs, links, name):

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -26,6 +26,10 @@ def add_virtualenv_config(filesystem, locator, installs, links):
     except filesystems.exceptions.FileNotFound:
         contents = tomlkit.table()
         contents.add('virtualenv', {})
+    if 'virtualenv' not in contents:
+        contents = tomlkit.table()
+        contents.add('virtualenv', {})
+
 
     contents["virtualenv"].add(
         "_".join(installs), {"install": list(installs), "link": list(links)}

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -79,7 +79,7 @@ def add_virtualenv_config(filesystem, locator, installs, links, name):
 @click.option(
     "--persist/--no-persist",
     is_flag=True,
-    default=True,
+    default=False,
     help="Add to config file when installing."
 )
 @click.argument("name", required=False)

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -137,7 +137,7 @@ def main(
             source=virtualenv.binary(name=link), to=link_dir.descendant(link)
         )
 
-    if installs and persist and not temporary:
+    if persist:
         add_virtualenv_config(
             filesystem=filesystem,
             locator=locator,

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -102,7 +102,7 @@ def main(
     if name:
         if temporary:
             raise click.BadParameter(
-                "specify only one of '-t / --temp / --temporary' or 'name'"
+                "specify only one of '-t / --temp / --temporary' or 'name'",
             )
 
         virtualenv = locator.for_name(name=name)

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -18,7 +18,7 @@ import tomlkit
 
 from venvs import __version__
 from venvs.common import (
-    _FILESYSTEM, _LINK_DIR, _ROOT, _dump_config, _load_config
+    _FILESYSTEM, _LINK_DIR, _ROOT, _dump_config, _load_config,
 )
 
 

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -78,6 +78,7 @@ def add_virtualenv_config(filesystem, locator, installs, links, name):
 )
 @click.option(
     "--persist/--no-persist",
+    "-p",
     is_flag=True,
     default=False,
     help="Add to config file when installing."

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -17,12 +17,12 @@ import click
 import tomlkit
 
 from venvs import __version__
-from venvs.common import _FILESYSTEM, _LINK_DIR, _ROOT, dump_config, load_config
+from venvs.common import _FILESYSTEM, _LINK_DIR, _ROOT, _dump_config, _load_config
 
 
 def add_virtualenv_config(filesystem, locator, installs, links, name):
     try:
-        contents = load_config(filesystem=filesystem, locator=locator)
+        contents = _load_config(filesystem=filesystem, locator=locator)
     except filesystems.exceptions.FileNotFound:
         contents = tomlkit.table()
         contents.add('virtualenv', {})
@@ -33,7 +33,7 @@ def add_virtualenv_config(filesystem, locator, installs, links, name):
     contents["virtualenv"].add(
         name, {"install": list(installs), "link": list(links)}
     )
-    dump_config(contents, filesystem=filesystem, locator=locator)
+    _dump_config(contents, filesystem=filesystem, locator=locator)
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -20,7 +20,7 @@ from venvs import __version__
 from venvs.common import _FILESYSTEM, _LINK_DIR, _ROOT, dump_config, load_config
 
 
-def add_virtualenv_config(filesystem, locator, installs, links):
+def add_virtualenv_config(filesystem, locator, installs, links, name):
     try:
         contents = load_config(filesystem=filesystem, locator=locator)
     except filesystems.exceptions.FileNotFound:
@@ -30,9 +30,8 @@ def add_virtualenv_config(filesystem, locator, installs, links):
         contents = tomlkit.table()
         contents.add('virtualenv', {})
 
-
     contents["virtualenv"].add(
-        "_".join(installs), {"install": list(installs), "link": list(links)}
+        name, {"install": list(installs), "link": list(links)}
     )
     dump_config(contents, filesystem=filesystem, locator=locator)
 
@@ -137,7 +136,11 @@ def main(
             source=virtualenv.binary(name=link), to=link_dir.descendant(link)
         )
 
-    if installs and config:
+    if installs and config and not temporary:
         add_virtualenv_config(
-            filesystem=filesystem, locator=locator, installs=installs, links=links
+            filesystem=filesystem,
+            locator=locator,
+            installs=installs,
+            links=links,
+            name=name,
         )

--- a/venvs/make.py
+++ b/venvs/make.py
@@ -77,7 +77,7 @@ def add_virtualenv_config(filesystem, locator, installs, links, name):
     help="create or reuse the global temporary virtualenv",
 )
 @click.option(
-    "--config/--no-config",
+    "--persist/--no-persist",
     is_flag=True,
     default=True,
     help="Add to config file when installing."
@@ -96,7 +96,7 @@ def main(
     requirements,
     recreate,
     virtualenv_args,
-    config,
+    persist,
 ):
     if name:
         if temporary:
@@ -136,7 +136,7 @@ def main(
             source=virtualenv.binary(name=link), to=link_dir.descendant(link)
         )
 
-    if installs and config and not temporary:
+    if installs and persist and not temporary:
         add_virtualenv_config(
             filesystem=filesystem,
             locator=locator,

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -170,6 +170,8 @@ class TestMake(CLIMixin, TestCase):
     def test_install_no_persist(self):
         """Install --no-persist does not edit the config file."""
         self.run_cli(["-l", "foo", "-i", "bar", "--no-persist"])
+
+        # No file has been created.
         with self.assertRaises(filesystems.exceptions.FileNotFound):
             _load_config(filesystem=self.filesystem, locator=self.locator)
 

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -149,6 +149,12 @@ class TestMake(CLIMixin, TestCase):
             {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
         )
 
+    def test_install_noconfig(self):
+        """Install --no-config will not edit the config file."""
+        self.run_cli(["-l", "foo", "-i", "bar", "--no-config"])
+        with self.assertRaises(filesystems.exceptions.FileNotFound):
+            load_config(filesystem=self.filesystem, locator=self.locator)
+
 
 class TestIntegration(TestCase):
     def setUp(self):

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -149,6 +149,23 @@ class TestMake(CLIMixin, TestCase):
             {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
         )
 
+    def test_handle_empty_config_file(self):
+        """Don't'break with an empty config file."""
+
+        # Empty the config file.
+        with self.filesystem.open(
+                self.locator.root.descendant("virtualenvs.toml"),
+                "w",
+        ):
+            pass
+
+        self.run_cli(["-l", "foo", "-i", "bar"])
+        contents = load_config(filesystem=self.filesystem, locator=self.locator)
+        self.assertEqual(
+            contents,
+            {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
+        )
+
     def test_install_noconfig(self):
         """Install --no-config will not edit the config file."""
         self.run_cli(["-l", "foo", "-i", "bar", "--no-config"])

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -143,7 +143,10 @@ class TestMake(CLIMixin, TestCase):
     def test_install_edit_config(self):
         """Install will automatically edit the config file."""
         self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
-        contents = _load_config(filesystem=self.filesystem, locator=self.locator)
+        contents = _load_config(
+            filesystem=self.filesystem,
+            locator=self.locator,
+        )
         self.assertEqual(
             contents,
             {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
@@ -160,7 +163,10 @@ class TestMake(CLIMixin, TestCase):
             pass
 
         self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
-        contents = _load_config(filesystem=self.filesystem, locator=self.locator)
+        contents = _load_config(
+            filesystem=self.filesystem,
+            locator=self.locator,
+        )
         self.assertEqual(
             contents,
             {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -142,7 +142,7 @@ class TestMake(CLIMixin, TestCase):
 
     def test_install_edit_config(self):
         """Install will automatically edit the config file."""
-        self.run_cli(["-l", "foo", "-i", "bar"])
+        self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
         contents = load_config(filesystem=self.filesystem, locator=self.locator)
         self.assertEqual(
             contents,
@@ -159,7 +159,7 @@ class TestMake(CLIMixin, TestCase):
         ):
             pass
 
-        self.run_cli(["-l", "foo", "-i", "bar"])
+        self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
         contents = load_config(filesystem=self.filesystem, locator=self.locator)
         self.assertEqual(
             contents,

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -5,7 +5,7 @@ from filesystems import Path
 import filesystems.native
 
 from venvs import find, make
-from venvs.common import Locator
+from venvs.common import Locator, load_config
 from venvs.tests.utils import CLIMixin
 
 
@@ -139,6 +139,15 @@ class TestMake(CLIMixin, TestCase):
 
     def test_multiple_installs_one_link_no_name(self):
         self.run_cli(["-i", "foo", "-i", "bar", "-l", "foo"], exit_status=2)
+
+    def test_install_edit_config(self):
+        """Install will automatically edit the config file."""
+        self.run_cli(["-l", "foo", "-i", "bar"])
+        contents = load_config(filesystem=self.filesystem, locator=self.locator)
+        self.assertEqual(
+            contents,
+            {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
+        )
 
 
 class TestIntegration(TestCase):

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 import sys
 
-import attr
 from filesystems import Path
 import filesystems.native
 

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -141,7 +141,7 @@ class TestMake(CLIMixin, TestCase):
         self.run_cli(["-i", "foo", "-i", "bar", "-l", "foo"], exit_status=2)
 
     def test_install_edit_config(self):
-        """Install will automatically edit the config file."""
+        """Install --persist edits the config file."""
         self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
         contents = _load_config(
             filesystem=self.filesystem,
@@ -173,7 +173,7 @@ class TestMake(CLIMixin, TestCase):
         )
 
     def test_install_no_persist(self):
-        """Install --no-persist will not edit the config file."""
+        """Install --no-persist does not edit the config file."""
         self.run_cli(["-l", "foo", "-i", "bar", "--no-persist"])
         with self.assertRaises(filesystems.exceptions.FileNotFound):
             _load_config(filesystem=self.filesystem, locator=self.locator)

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 import sys
 
+import attr
 from filesystems import Path
 import filesystems.native
 
@@ -143,6 +144,7 @@ class TestMake(CLIMixin, TestCase):
     def test_install_edit_config(self):
         """Install --persist edits the config file."""
         self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
+
         contents = _load_config(
             filesystem=self.filesystem,
             locator=self.locator,
@@ -158,6 +160,19 @@ class TestMake(CLIMixin, TestCase):
         self.filesystem.touch(self.locator.root.descendant("virtualenvs.toml"))
 
         self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
+        contents = _load_config(
+            filesystem=self.filesystem,
+            locator=self.locator,
+        )
+        self.assertEqual(
+            contents,
+            {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
+        )
+
+    def test_handle_missing_config_directory(self):
+        """Create the config directory if it does not exist."""
+
+        raise NotImplementedError
         contents = _load_config(
             filesystem=self.filesystem,
             locator=self.locator,

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -166,7 +166,7 @@ class TestMake(CLIMixin, TestCase):
             {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
         )
 
-    def test_install_noconfig(self):
+    def test_install_no_persist(self):
         """Install --no-persist will not edit the config file."""
         self.run_cli(["-l", "foo", "-i", "bar", "--no-persist"])
         with self.assertRaises(filesystems.exceptions.FileNotFound):

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -155,12 +155,7 @@ class TestMake(CLIMixin, TestCase):
     def test_handle_empty_config_file(self):
         """Don't break with an empty config file."""
 
-        # Empty the config file.
-        with self.filesystem.open(
-                self.locator.root.descendant("virtualenvs.toml"),
-                "w",
-        ):
-            pass
+        self.filesystem.touch(self.locator.root.descendant("virtualenvs.toml"))
 
         self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
         contents = _load_config(

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -5,7 +5,7 @@ from filesystems import Path
 import filesystems.native
 
 from venvs import find, make
-from venvs.common import Locator, load_config
+from venvs.common import Locator, _load_config
 from venvs.tests.utils import CLIMixin
 
 
@@ -143,7 +143,7 @@ class TestMake(CLIMixin, TestCase):
     def test_install_edit_config(self):
         """Install will automatically edit the config file."""
         self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
-        contents = load_config(filesystem=self.filesystem, locator=self.locator)
+        contents = _load_config(filesystem=self.filesystem, locator=self.locator)
         self.assertEqual(
             contents,
             {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
@@ -160,7 +160,7 @@ class TestMake(CLIMixin, TestCase):
             pass
 
         self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
-        contents = load_config(filesystem=self.filesystem, locator=self.locator)
+        contents = _load_config(filesystem=self.filesystem, locator=self.locator)
         self.assertEqual(
             contents,
             {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
@@ -170,7 +170,7 @@ class TestMake(CLIMixin, TestCase):
         """Install --no-persist will not edit the config file."""
         self.run_cli(["-l", "foo", "-i", "bar", "--no-persist"])
         with self.assertRaises(filesystems.exceptions.FileNotFound):
-            load_config(filesystem=self.filesystem, locator=self.locator)
+            _load_config(filesystem=self.filesystem, locator=self.locator)
 
 
 class TestIntegration(TestCase):

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -169,10 +169,13 @@ class TestMake(CLIMixin, TestCase):
             {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
         )
 
-    def test_handle_missing_config_directory(self):
+    def test_persist_handles_missing_config_directory(self):
         """Create the config directory if it does not exist."""
 
-        raise NotImplementedError
+        self.filesystem.remove_empty_directory(self.locator.root)
+
+        self.run_cli(["-l", "foo", "-i", "bar", "--persist"])
+
         contents = _load_config(
             filesystem=self.filesystem,
             locator=self.locator,
@@ -180,6 +183,22 @@ class TestMake(CLIMixin, TestCase):
         self.assertEqual(
             contents,
             {'virtualenv': {"bar": {"install": ["bar"], "link": ["foo"]}}}
+        )
+
+    def test_no_persist_handles_missing_virtualenv_directory(self):
+        """Don't break if there is no virtualenv directory."""
+
+        self.filesystem.remove_empty_directory(self.locator.root)
+
+        self.run_cli(["-l", "foo", "-i", "bar", "--no-persist"])
+
+        self.assertTrue(self.filesystem.exists(self.locator.root))
+
+        # Config file has _not_ been created.
+        self.assertFalse(
+            self.filesystem.exists(
+                self.locator.root.descendant("virtualenvs.toml")
+            )
         )
 
     def test_install_no_persist(self):

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -153,7 +153,7 @@ class TestMake(CLIMixin, TestCase):
         )
 
     def test_handle_empty_config_file(self):
-        """Don't'break with an empty config file."""
+        """Don't break with an empty config file."""
 
         # Empty the config file.
         with self.filesystem.open(

--- a/venvs/tests/test_make.py
+++ b/venvs/tests/test_make.py
@@ -167,8 +167,8 @@ class TestMake(CLIMixin, TestCase):
         )
 
     def test_install_noconfig(self):
-        """Install --no-config will not edit the config file."""
-        self.run_cli(["-l", "foo", "-i", "bar", "--no-config"])
+        """Install --no-persist will not edit the config file."""
+        self.run_cli(["-l", "foo", "-i", "bar", "--no-persist"])
         with self.assertRaises(filesystems.exceptions.FileNotFound):
             load_config(filesystem=self.filesystem, locator=self.locator)
 

--- a/venvs/tests/utils.py
+++ b/venvs/tests/utils.py
@@ -57,6 +57,12 @@ class CLIMixin(object):
         return packages, reqs
 
     def fake_create(self, virtualenv, **kwargs):
+
+        try:
+            self.filesystem.create_directory(path=virtualenv.path.parent())
+        except FileExists:
+            pass
+
         try:
             self.filesystem.create_directory(path=virtualenv.path)
         except FileExists:


### PR DESCRIPTION
This adds a dependency on [`tomlkit`](https://github.com/sdispater/tomlkit), which says

> It includes a parser that preserves all comments, indentations, whitespace and internal element ordering, and makes them accessible and editable via an intuitive API.